### PR TITLE
ROS 2 Jazzy: refactor IMU node, add CRC header, and update build files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,13 @@
 # WHEELTEC_N100_IMU_ROS2
 
+WHEELTEC N100 IMU ROS2 driver package.
 
+## Branches
+- `jazzy`: tuned for ROS 2 Jazzy / Ubuntu 24.04.
+
+## Quick run
+```bash
+ros2 run wheeltec_n100_imu imu_node --ros-args -p serial_port:=/dev/ttyUSB0
 ```
-ros2 run wheeltec_n100_imu imu_node --ros-args -p serial_port:="/dev/ttyUSB0" 
-```
-It worked on ubuntu 20.04 and ros2 foxy 
+
+> 기존 `work` 브랜치는 실험 코드용으로 남겨두고, `jazzy` 브랜치에서 안정화/최적화를 진행했습니다.

--- a/ros2_wheeltec_n100_imu/CMakeLists.txt
+++ b/ros2_wheeltec_n100_imu/CMakeLists.txt
@@ -8,7 +8,7 @@ endif()
 
 # Default to C++14
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD 17)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
@@ -19,27 +19,23 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(sensor_msgs REQUIRED)
-find_package(std_msgs REQUIRED)
 find_package(serial REQUIRED)
 find_package(Eigen3 REQUIRED)
 set(Eigen3_INCLUDE_DIRS ${EIGEN3_INCLUDE_DIR})
 find_package(tf2 REQUIRED)
-find_package(rcl_interfaces REQUIRED)
 
 
 # uncomment the following section in order to fill in
 # further dependencies manually.
 # find_package(<dependency> REQUIRED)
 
-add_executable(imu_node src/imu_node.cpp)
+add_executable(imu_node src/imu_node.cpp src/crc_table.cpp)
 ament_target_dependencies(imu_node
   rclcpp
   sensor_msgs
-  std_msgs
   serial
   Eigen3
   tf2
-  rcl_interfaces
 )
 target_include_directories(imu_node PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/ros2_wheeltec_n100_imu/include/wheeltec_n100_imu/crc_table.hpp
+++ b/ros2_wheeltec_n100_imu/include/wheeltec_n100_imu/crc_table.hpp
@@ -1,0 +1,11 @@
+#ifndef WHEELTEC_N100_IMU__CRC_TABLE_HPP_
+#define WHEELTEC_N100_IMU__CRC_TABLE_HPP_
+
+#include <cstddef>
+#include <cstdint>
+
+uint8_t CRC8_Table(const uint8_t * p, std::size_t counter);
+uint16_t CRC16_Table(const uint8_t * p, std::size_t counter);
+uint32_t CRC32_Table(const uint8_t * p, std::size_t counter);
+
+#endif  // WHEELTEC_N100_IMU__CRC_TABLE_HPP_

--- a/ros2_wheeltec_n100_imu/include/wheeltec_n100_imu/imu_node.hpp
+++ b/ros2_wheeltec_n100_imu/include/wheeltec_n100_imu/imu_node.hpp
@@ -1,46 +1,38 @@
-#include <cstdio>
-#include <unistd.h>
+#ifndef WHEELTEC_N100_IMU__IMU_NODE_HPP_
+#define WHEELTEC_N100_IMU__IMU_NODE_HPP_
 
 #include <chrono>
-#include <functional>
-#include <memory>
+#include <cstdint>
 #include <string>
+#include <vector>
 
+#include <Eigen/Eigen>
+#include <geometry_msgs/msg/pose2_d.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/imu.hpp>
 #include <sensor_msgs/msg/magnetic_field.hpp>
-#include <std_msgs/msg/string.hpp>
-#include <geometry_msgs/msg/pose2_d.hpp>
+#include <tf2/LinearMath/Quaternion.h>
 
 #include "serial/serial.h"
-#include "tf2/transform_datatypes.h"
- #include <tf2/LinearMath/Quaternion.h>
-#include <Eigen/Eigen>
-
-
 #include "wheeltec_n100_imu/fdilink_data_struct.h"
-
-
-// #include <rcl_interfaces>
 
 using namespace std::chrono_literals;
 
+constexpr uint8_t FRAME_HEAD = 0xfc;
+constexpr uint8_t FRAME_END = 0xfd;
+constexpr uint8_t TYPE_IMU = 0x40;
+constexpr uint8_t TYPE_AHRS = 0x41;
+constexpr uint8_t TYPE_INSGPS = 0x42;
+constexpr uint8_t TYPE_GROUND = 0xf0;
+constexpr uint8_t IMU_LEN = 0x38;
+constexpr uint8_t AHRS_LEN = 0x30;
+constexpr uint8_t INSGPS_LEN = 0x54;
 
-#define FRAME_HEAD 0xfc
-#define FRAME_END 0xfd
-#define TYPE_IMU 0x40
-#define TYPE_AHRS 0x41
-#define TYPE_INSGPS 0x42
-#define TYPE_GROUND 0xf0
-#define IMU_LEN  0x38   //56
-#define AHRS_LEN 0x30   //48
-#define INSGPS_LEN 0x54 //84
-#define PI 3.141592653589793
-#define DEG_TO_RAD 0.017453292519943295
-// Sample covariance
-#define IMU_MAG_COV {0.01, 0.01, 0.01}
-#define IMU_GYRO_COV {0.01, 0.01, 0.01}
-#define IMU_ACCEL_COV {0.05, 0.05, 0.05}
+constexpr double PI = 3.141592653589793;
+constexpr double MAG_SCALE_MILLI_GAUSS_TO_TESLA = 1.0e-7;
 
+const std::vector<double> IMU_MAG_COV = {0.01, 0.01, 0.01};
+const std::vector<double> IMU_GYRO_COV = {0.01, 0.01, 0.01};
+const std::vector<double> IMU_ACCEL_COV = {0.05, 0.05, 0.05};
 
-
+#endif  // WHEELTEC_N100_IMU__IMU_NODE_HPP_

--- a/ros2_wheeltec_n100_imu/package.xml
+++ b/ros2_wheeltec_n100_imu/package.xml
@@ -13,10 +13,8 @@
   <test_depend>ament_lint_common</test_depend>
   <depend>serial</depend>
   <depend>rclcpp</depend>
-  <depend>std_msgs</depend>
   <depend>sensor_msgs</depend>
   <depend>tf2</depend>
-  <depend>rcl_interfaces</depend>
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/ros2_wheeltec_n100_imu/src/crc_table.cpp
+++ b/ros2_wheeltec_n100_imu/src/crc_table.cpp
@@ -1,5 +1,4 @@
-#include <stdint.h>
-// #include "wheeltecN100_imu/crc_table.h"
+#include "wheeltec_n100_imu/crc_table.hpp"
 
 static const uint8_t CRC8Table[] = {
     0, 94, 188, 226, 97, 63, 221, 131, 194, 156, 126, 32, 163, 253, 31, 65,
@@ -123,10 +122,10 @@ static const uint32_t CRC32Table[] = {
 };
 
 
-uint8_t CRC8_Table(uint8_t* p, uint8_t counter)
+uint8_t CRC8_Table(const uint8_t * p, std::size_t counter)
 {
     uint8_t crc8 = 0;
-    for (int i = 0; i < counter; i++)
+    for (std::size_t i = 0; i < counter; i++)
     {
         uint8_t value = p[i];
         uint8_t new_index = crc8 ^ value;
@@ -136,10 +135,10 @@ uint8_t CRC8_Table(uint8_t* p, uint8_t counter)
 }
 
 
-uint16_t CRC16_Table(uint8_t *p, uint8_t counter)
+uint16_t CRC16_Table(const uint8_t * p, std::size_t counter)
 {
     uint16_t crc16 = 0;
-    for (int i = 0; i < counter; i++)
+    for (std::size_t i = 0; i < counter; i++)
     {
         uint8_t value = p[i];
         crc16 = CRC16Table[((crc16 >> 8) ^ value) & 0xff] ^ (crc16 << 8);
@@ -147,13 +146,13 @@ uint16_t CRC16_Table(uint8_t *p, uint8_t counter)
     return (crc16);
 }
 
-uint32_t CRC32_Table(uint8_t *p, uint8_t counter)
+uint32_t CRC32_Table(const uint8_t * p, std::size_t counter)
 {
-    uint16_t crc32 = 0;
-    for (int i = 0; i < counter; i++)
+    uint32_t crc32 = 0xFFFFFFFFu;
+    for (std::size_t i = 0; i < counter; i++)
     {
         uint8_t value = p[i];
-        crc32 = CRC16Table[((crc32 >> 8) ^ value) & 0xff] ^ (crc32 << 8);
+        crc32 = CRC32Table[(crc32 ^ value) & 0xFFu] ^ (crc32 >> 8);
     }
-    return (crc32);
+    return (~crc32);
 }

--- a/ros2_wheeltec_n100_imu/src/imu_node.cpp
+++ b/ros2_wheeltec_n100_imu/src/imu_node.cpp
@@ -1,634 +1,402 @@
-// --------------------------------------------------
-// created by: Nipun Dhananjaya  31/05/2023
-// ---------------------------------------------------
-
 #include "wheeltec_n100_imu/imu_node.hpp"
-#include "crc_table.cpp"
 
+#include <algorithm>
+#include <array>
+#include <stdexcept>
+#include <cmath>
+#include <utility>
 
-
+#include "wheeltec_n100_imu/crc_table.hpp"
 
 class ImuNode : public rclcpp::Node
 {
 public:
-  ImuNode() 
+  ImuNode()
   : Node("imu_node")
   {
-    // declare parametes
-    this->declare_parameter("debug", false);
-    this->declare_parameter("serial_port", "/dev/ttyACM0");
-    this->declare_parameter("serial_baud", 921600);
-    this->declare_parameter("serial_timeout", 20);
-    this->declare_parameter("device_type", 1);
-    this->declare_parameter("frist_sn", false);
-    this->declare_parameter("imu_topic", "imu");
-    this->declare_parameter("imu_frame", "imu");
-    this->declare_parameter("mag_pose_2d_topic", "magnetic_pose_2d");
-    this->declare_parameter("imu_trueEast_topic", "imu_trueEast");
-    this->declare_parameter("mag_topic", "magnetic_field");
-    this->declare_parameter("yaw_offset", -2.094);
-    this->declare_parameter("mag_offset_x", 0.0);
-    this->declare_parameter("mag_offset_y", 0.0);
-    this->declare_parameter("mag_offset_z", 0.0);
-    this->declare_parameter("imu_mag_covVec",std::vector<double>(IMU_MAG_COV));
-    this->declare_parameter("imu_gyro_covVec", std::vector<double>(IMU_GYRO_COV));
-    this->declare_parameter("imu_accel_covVec", std::vector<double>(IMU_ACCEL_COV));
+    declare_parameters();
+    load_parameters();
 
-    // get parameters
-    if_debug_ = this->get_parameter("debug").as_bool();
-    serial_port_ = this->get_parameter("serial_port").as_string();
-    serial_baud_ = this->get_parameter("serial_baud").as_int();
-    serial_timeout_ = this->get_parameter("serial_timeout").as_int();
-    device_type_ = this->get_parameter("device_type").as_int();
-    frist_sn_ = this->get_parameter("frist_sn").as_bool();
-    imu_topic_ = this->get_parameter("imu_topic").as_string();
-    mag_pose_2d_topic_ = this->get_parameter("mag_pose_2d_topic").as_string();
-    imu_trueEast_topic_ = this->get_parameter("imu_trueEast_topic").as_string();
-    mag_topic_ = this->get_parameter("mag_topic").as_string();
-    imu_frame_id_ = this->get_parameter("imu_frame").as_string();
-    yaw_offset_ = this->get_parameter("yaw_offset").as_double();
-    mag_offset_x_ = this->get_parameter("mag_offset_x").as_double();
-    mag_offset_y_ = this->get_parameter("mag_offset_y").as_double();
-    mag_offset_z_ = this->get_parameter("mag_offset_z").as_double();
-    this->get_parameter("imu_mag_covVec").as_double_array();
-    this->get_parameter("imu_gyro_covVec").as_double_array();
-    this->get_parameter("imu_accel_covVec").as_double_array();
+    q_rot_.setRPY(0.0, 0.0, yaw_offset_);
 
-    q_rot.setRPY(0, 0, yaw_offset_);
+    imu_pub_ = create_publisher<sensor_msgs::msg::Imu>(imu_topic_, 10);
+    imu_true_east_pub_ = create_publisher<sensor_msgs::msg::Imu>(imu_true_east_topic_, 10);
+    mag_pose_pub_ = create_publisher<geometry_msgs::msg::Pose2D>(mag_pose_2d_topic_, 10);
+    mag_pub_ = create_publisher<sensor_msgs::msg::MagneticField>(mag_topic_, 10);
 
-    std::vector<rclcpp::Parameter> all_new_parameters{ \
-      rclcpp::Parameter("debug", false), \
-      rclcpp::Parameter("serial_port", "/dev/ttyACM0"), \
-      rclcpp::Parameter("serial_baud", 921600), \
-      rclcpp::Parameter("serial_timeout", 20), \
-      rclcpp::Parameter("device_type", 1), \
-      rclcpp::Parameter("frist_sn", false), \
-      rclcpp::Parameter("imu_topic", "imu"), \
-      rclcpp::Parameter("imu_frame", "imu"), \
-      rclcpp::Parameter("mag_pose_2d_topic", "magnetic_pose_2d"), \
-      rclcpp::Parameter("imu_trueEast_topic", "imu_trueEast"), \
-      rclcpp::Parameter("mag_topic", "magnetic_field"), \
-      rclcpp::Parameter("yaw_offset", -2.094), \
-      rclcpp::Parameter("mag_offset_x", 0.0), \
-      rclcpp::Parameter("mag_offset_y", 0.0), \
-      rclcpp::Parameter("mag_offset_z", 0.0), \
-      rclcpp::Parameter("imu_mag_covVec",std::vector<double>(IMU_MAG_COV)), \
-      rclcpp::Parameter("imu_gyro_covVec", std::vector<double>(IMU_GYRO_COV)), \
-      rclcpp::Parameter("imu_accel_covVec", std::vector<double>(IMU_ACCEL_COV))
-      };
-
-    
-   
-    // q_rot.setRPY(0,0,yaw_offset_);
-
-    // """ publishers """
-    imu_pub_ = this->create_publisher<sensor_msgs::msg::Imu>(imu_topic_.c_str(), 10);
-    imu_trueEast_pub_ = this->create_publisher<sensor_msgs::msg::Imu>(imu_trueEast_topic_.c_str(), 10);
-    mag_pose_pub_ = this->create_publisher<geometry_msgs::msg::Pose2D>(mag_pose_2d_topic_.c_str(), 10);
-    mag_pub_ = this->create_publisher<sensor_msgs::msg::MagneticField>(mag_topic_.c_str(), 10);
-    // """callback"""
-    timer_ = this->create_wall_timer(10ms, std::bind(&ImuNode::read_imu, this));
-    
-    // """ setup serial """
-    try
-    {
-      {
-        serial_.setPort(serial_port_.c_str());
-        serial_.setBaudrate(serial_baud_);
-        serial_.setFlowcontrol(serial::flowcontrol_none);
-        serial_.setParity(serial::parity_none);
-        serial_.setStopbits(serial::stopbits_one);
-        serial_.setBytesize(serial::eightbits);
-        serial::Timeout time_out = serial::Timeout::simpleTimeout(serial_timeout_);
-        serial_.setTimeout(time_out);
-        serial_.open();
-      }
-    }
-    catch(serial::IOException& e)
-    {
-      RCLCPP_ERROR_STREAM_THROTTLE(this->get_logger(), *this->get_clock(), 1000, "Unable to open serial port " << serial_port_.c_str());
-      exit(0);
-    }
-    if (serial_.isOpen())
-    {
-      RCLCPP_INFO_STREAM_ONCE(this->get_logger(), "Initialized Serial port " << serial_port_.c_str());
-    }
-    else
-    {
-      RCLCPP_ERROR_STREAM_THROTTLE(this->get_logger(), *this->get_clock(), 1000, "Unable to initialize serial port " << serial_port_.c_str());
-    }
+    setup_serial();
+    timer_ = create_wall_timer(2ms, std::bind(&ImuNode::read_imu, this));
   }
-
-  
 
 private:
-  
-  
-  serial::Serial serial_;
+  void declare_parameters()
+  {
+    declare_parameter("debug", false);
+    declare_parameter("serial_port", "/dev/ttyACM0");
+    declare_parameter("serial_baud", 921600);
+    declare_parameter("serial_timeout", 20);
+    declare_parameter("device_type", 1);
+    declare_parameter("frist_sn", false);
+    declare_parameter("imu_topic", "imu");
+    declare_parameter("imu_frame", "imu");
+    declare_parameter("mag_pose_2d_topic", "magnetic_pose_2d");
+    declare_parameter("imu_trueEast_topic", "imu_trueEast");
+    declare_parameter("mag_topic", "magnetic_field");
+    declare_parameter("yaw_offset", -2.094);
+    declare_parameter("mag_offset_x", 0.0);
+    declare_parameter("mag_offset_y", 0.0);
+    declare_parameter("mag_offset_z", 0.0);
+    declare_parameter("imu_mag_covVec", IMU_MAG_COV);
+    declare_parameter("imu_gyro_covVec", IMU_GYRO_COV);
+    declare_parameter("imu_accel_covVec", IMU_ACCEL_COV);
+  }
 
-  bool if_debug_;
-  // serial
-  std::string serial_port_;
-  std::uint32_t serial_baud_;
-  std::uint8_t serial_timeout_;
-  // sum info
-  int sn_lost_ = 0;
-  int crc_error_ = 0;
-  uint8_t read_sn_ = 0;
-  bool frist_sn_;
-  int device_type_ = 1;
-  // covariance info
-  std::vector<double> imu_mag_cov;
-  std::vector<double> imu_gyro_cov;
-  std::vector<double> imu_accel_cov;
+  void load_parameters()
+  {
+    if_debug_ = get_parameter("debug").as_bool();
+    serial_port_ = get_parameter("serial_port").as_string();
+    serial_baud_ = static_cast<uint32_t>(get_parameter("serial_baud").as_int());
+    serial_timeout_ = static_cast<uint32_t>(get_parameter("serial_timeout").as_int());
+    device_type_ = static_cast<int>(get_parameter("device_type").as_int());
+    first_sn_ = get_parameter("frist_sn").as_bool();
 
-  // ros2 topics
-  std::string imu_topic_;
-  std::string mag_pose_2d_topic_;
-  std::string imu_trueEast_topic_;
-  std::string mag_topic_;
-  // ros2 frame
-  std::string imu_frame_id_;
-  // others
-  double yaw_offset_;
-  tf2::Quaternion q_rot;
-  double mag_offset_x_;
-  double mag_offset_y_;
-  double mag_offset_z_;
-  double mag_covariance_;
-  // data
-  FDILink::imu_frame_read  imu_frame_;
-  FDILink::ahrs_frame_read ahrs_frame_;
-  FDILink::insgps_frame_read insgps_frame_;
+    imu_topic_ = get_parameter("imu_topic").as_string();
+    imu_true_east_topic_ = get_parameter("imu_trueEast_topic").as_string();
+    mag_pose_2d_topic_ = get_parameter("mag_pose_2d_topic").as_string();
+    mag_topic_ = get_parameter("mag_topic").as_string();
+    imu_frame_id_ = get_parameter("imu_frame").as_string();
 
-  // callback function
+    yaw_offset_ = get_parameter("yaw_offset").as_double();
+    mag_offset_x_ = get_parameter("mag_offset_x").as_double();
+    mag_offset_y_ = get_parameter("mag_offset_y").as_double();
+    mag_offset_z_ = get_parameter("mag_offset_z").as_double();
+
+    imu_mag_cov_ = get_parameter("imu_mag_covVec").as_double_array();
+    imu_gyro_cov_ = get_parameter("imu_gyro_covVec").as_double_array();
+    imu_accel_cov_ = get_parameter("imu_accel_covVec").as_double_array();
+
+    mag_covariance_ = imu_mag_cov_.empty() ? 0.0 : imu_mag_cov_[0];
+  }
+
+  void setup_serial()
+  {
+    try {
+      serial_.setPort(serial_port_);
+      serial_.setBaudrate(serial_baud_);
+      serial_.setFlowcontrol(serial::flowcontrol_none);
+      serial_.setParity(serial::parity_none);
+      serial_.setStopbits(serial::stopbits_one);
+      serial_.setBytesize(serial::eightbits);
+      serial_.setTimeout(serial::Timeout::simpleTimeout(serial_timeout_));
+      serial_.open();
+    } catch (const serial::IOException & e) {
+      RCLCPP_FATAL(get_logger(), "Unable to open serial port %s (%s)", serial_port_.c_str(), e.what());
+      throw;
+    }
+
+    if (!serial_.isOpen()) {
+      throw std::runtime_error("Serial port failed to open: " + serial_port_);
+    }
+
+    RCLCPP_INFO(get_logger(), "Initialized serial port: %s @ %u", serial_port_.c_str(), serial_baud_);
+  }
+
+  bool read_exact(uint8_t * buffer, size_t bytes)
+  {
+    return serial_.read(buffer, bytes) == bytes;
+  }
+
   void read_imu()
   {
-    RCLCPP_INFO_STREAM_ONCE(this->get_logger(), "Starting to read IMU\n" );
-    while(rclcpp::ok())
-    {
-      if (!serial_.isOpen()){
-        RCLCPP_WARN_STREAM_SKIPFIRST(this->get_logger(), "Serial is not open");
-      }
-      // check head start
-      uint8_t check_head[1] = {0xff};
-      size_t head_s = serial_.read(check_head, 1);
-      if (if_debug_){
-        if (head_s != 1)
-        {
-          RCLCPP_ERROR_STREAM_THROTTLE(this->get_logger(), *this->get_clock(), 1000, "Read serial port time out! can't read pack head. " );
-        }
-        std::cout << std::endl;
-        std::cout << "check_head: " << std::hex << (int)check_head[0] << std::dec << std::endl;
-      }
-      if (check_head[0] != FRAME_HEAD)
-      {
-        continue;
-      }
-      //check head type
-      uint8_t head_type[1] = {0xff};
-      size_t type_s = serial_.read(head_type, 1);
-      if (if_debug_){
-        std::cout << "head_type:  " << std::hex << (int)head_type[0] << std::dec << std::endl;
-      }
-      if (head_type[0] != TYPE_IMU && head_type[0] != TYPE_AHRS && head_type[0] != TYPE_INSGPS && head_type[0] != 0x50 && head_type[0] != TYPE_GROUND)
-      {
-        RCLCPP_WARN_STREAM_SKIPFIRST(this->get_logger(), "head_type error: " << head_type[0]);
-        continue;
-      }
-      //check head length
-      uint8_t check_len[1] = {0xff};
-      size_t len_s = serial_.read(check_len, 1);
-      if (if_debug_){
-        std::cout << "check_len: "<< std::dec << (int)check_len[0]  << std::endl;
-      }
-      if (head_type[0] == TYPE_IMU && check_len[0] != IMU_LEN)
-      {
-        RCLCPP_WARN_STREAM_SKIPFIRST(this->get_logger(), "head_len error (imu)");
-        continue;
-      }else if (head_type[0] == TYPE_AHRS && check_len[0] != AHRS_LEN)
-      {
-        RCLCPP_WARN_STREAM_SKIPFIRST(this->get_logger(), "head_len error (ahrs)");
-        continue;
-      }else if (head_type[0] == TYPE_INSGPS && check_len[0] != INSGPS_LEN)
-      {
-        RCLCPP_WARN_STREAM_SKIPFIRST(this->get_logger(), "head_len error (insgps)");
-        continue;
-      }
-      else if (head_type[0] == TYPE_GROUND || head_type[0] == 0x50) // Unknown data, prevent record failure
-      {
-        uint8_t ground_sn[1];
-        size_t ground_sn_s = serial_.read(ground_sn, 1);
-        if (++read_sn_ != ground_sn[0])
-        {
-          if ( ground_sn[0] < read_sn_)
-          {
-            if(if_debug_){
-              RCLCPP_WARN_STREAM_SKIPFIRST(this->get_logger(), "detected sn lost.");
-            }
-            sn_lost_ += 256 - (int)(read_sn_ - ground_sn[0]);
-            read_sn_ = ground_sn[0];
-            // continue;
-          }
-          else
-          {
-            if(if_debug_){
-              RCLCPP_WARN_STREAM_SKIPFIRST(this->get_logger(),"detected sn lost.");
-            }
-            sn_lost_ += (int)(ground_sn[0] - read_sn_);
-            read_sn_ = ground_sn[0];
-            // continue;
-          }
-        }
-        uint8_t ground_ignore[500];
-        size_t ground_ignore_s = serial_.read(ground_ignore, (check_len[0]+4));
-        continue;
-      }
-      //read head sn
-      uint8_t check_sn[1] = {0xff};
-      size_t sn_s = serial_.read(check_sn, 1);
-      uint8_t head_crc8[1] = {0xff};
-      size_t crc8_s = serial_.read(head_crc8, 1);
-      uint8_t head_crc16_H[1] = {0xff};
-      uint8_t head_crc16_L[1] = {0xff};
-      size_t crc16_H_s = serial_.read(head_crc16_H, 1);
-      size_t crc16_L_s = serial_.read(head_crc16_L, 1);
-      if (if_debug_){
-        std::cout << "check_sn: "     << std::hex << (int)check_sn[0]     << std::dec << std::endl;
-        std::cout << "head_crc8: "    << std::hex << (int)head_crc8[0]    << std::dec << std::endl;
-        std::cout << "head_crc16_H: " << std::hex << (int)head_crc16_H[0] << std::dec << std::endl;
-        std::cout << "head_crc16_L: " << std::hex << (int)head_crc16_L[0] << std::dec << std::endl;
-      }
-       // put header & check crc8 & count sn lost
-      if (head_type[0] == TYPE_IMU)
-      {
-        imu_frame_.frame.header.header_start   = check_head[0];
-        imu_frame_.frame.header.data_type      = head_type[0];
-        imu_frame_.frame.header.data_size      = check_len[0];
-        imu_frame_.frame.header.serial_num     = check_sn[0];
-        imu_frame_.frame.header.header_crc8    = head_crc8[0];
-        imu_frame_.frame.header.header_crc16_h = head_crc16_H[0];
-        imu_frame_.frame.header.header_crc16_l = head_crc16_L[0];
-        uint8_t CRC8 = CRC8_Table(imu_frame_.read_buf.frame_header, 4);
-        if (CRC8 != imu_frame_.frame.header.header_crc8)
-        {
-          RCLCPP_WARN_STREAM_SKIPFIRST(this->get_logger(),"header_crc8 error");
-          continue;
-        }
-        if(!frist_sn_){
-          read_sn_  = imu_frame_.frame.header.serial_num - 1;
-          frist_sn_ = true;
-        }
-        //check sn
-        checkSN(TYPE_IMU);
-      }
-      else if (head_type[0] == TYPE_AHRS)
-      {
-        ahrs_frame_.frame.header.header_start   = check_head[0];
-        ahrs_frame_.frame.header.data_type      = head_type[0];
-        ahrs_frame_.frame.header.data_size      = check_len[0];
-        ahrs_frame_.frame.header.serial_num     = check_sn[0];
-        ahrs_frame_.frame.header.header_crc8    = head_crc8[0];
-        ahrs_frame_.frame.header.header_crc16_h = head_crc16_H[0];
-        ahrs_frame_.frame.header.header_crc16_l = head_crc16_L[0];
-        uint8_t CRC8 = CRC8_Table(ahrs_frame_.read_buf.frame_header, 4);
-        if (CRC8 != ahrs_frame_.frame.header.header_crc8)
-        {
-          RCLCPP_WARN_STREAM_SKIPFIRST(this->get_logger(),"header_crc8 error");
-          continue;
-        }
-        if(!frist_sn_){
-          read_sn_  = ahrs_frame_.frame.header.serial_num - 1;
-          frist_sn_ = true;
-        }
-        //check sn
-        checkSN(TYPE_AHRS);
-      }
-      else if (head_type[0] == TYPE_INSGPS)
-      {
-        insgps_frame_.frame.header.header_start   = check_head[0];
-        insgps_frame_.frame.header.data_type      = head_type[0];
-        insgps_frame_.frame.header.data_size      = check_len[0];
-        insgps_frame_.frame.header.serial_num     = check_sn[0];
-        insgps_frame_.frame.header.header_crc8    = head_crc8[0];
-        insgps_frame_.frame.header.header_crc16_h = head_crc16_H[0];
-        insgps_frame_.frame.header.header_crc16_l = head_crc16_L[0];
-        uint8_t CRC8 = CRC8_Table(insgps_frame_.read_buf.frame_header, 4);
-        if (CRC8 != insgps_frame_.frame.header.header_crc8)
-        {
-          RCLCPP_WARN_STREAM_SKIPFIRST(this->get_logger(),"header_crc8 error");
-          continue;
-        }
-        else if(if_debug_)
-        {
-          std::cout << "header_crc8 matched." << std::endl;
-        }
-        checkSN(TYPE_INSGPS);
-      }
-      if (head_type[0] == TYPE_IMU)
-      {
-        uint16_t head_crc16_l = imu_frame_.frame.header.header_crc16_l;
-        uint16_t head_crc16_h = imu_frame_.frame.header.header_crc16_h;
-        uint16_t head_crc16 = head_crc16_l + (head_crc16_h << 8);
-        size_t data_s = serial_.read(imu_frame_.read_buf.read_msg, (IMU_LEN + 1)); //48+1
-        // if (if_debug_){
-        //   for (size_t i = 0; i < (IMU_LEN + 1); i++)
-        //   {
-        //     std::cout << std::hex << (int)imu_frame_.read_buf.read_msg[i] << " ";
-        //   }
-        //   std::cout << std::dec << std::endl;
-        // }
-        uint16_t CRC16 = CRC16_Table(imu_frame_.frame.data.data_buff, IMU_LEN);
-        if (if_debug_){
-          std::cout << "CRC16:        " << std::hex << (int)CRC16 << std::dec << std::endl;
-          std::cout << "head_crc16:   " << std::hex << (int)head_crc16 << std::dec << std::endl;
-          std::cout << "head_crc16_h: " << std::hex << (int)head_crc16_h << std::dec << std::endl;
-          std::cout << "head_crc16_l: " << std::hex << (int)head_crc16_l << std::dec << std::endl;
-          bool if_right = ((int)head_crc16 == (int)CRC16);
-          std::cout << "if_right: " << if_right << std::endl;
-        }
-        if (head_crc16 != CRC16)
-        {
-          RCLCPP_WARN_STREAM_SKIPFIRST(this->get_logger(),"check crc16 faild(imu).");
-          continue;
-        }
-        else if(imu_frame_.frame.frame_end != FRAME_END)
-        {
-          RCLCPP_WARN_STREAM_SKIPFIRST(this->get_logger(),"check frame end.");
-          continue;
-        }
-      }
-      else if (head_type[0] == TYPE_AHRS)
-      {
-        uint16_t head_crc16_l = ahrs_frame_.frame.header.header_crc16_l;
-        uint16_t head_crc16_h = ahrs_frame_.frame.header.header_crc16_h;
-        uint16_t head_crc16 = head_crc16_l + (head_crc16_h << 8);
-        size_t data_s = serial_.read(ahrs_frame_.read_buf.read_msg, (AHRS_LEN + 1)); //48+1
-        // if (if_debug_){
-        //   for (size_t i = 0; i < (AHRS_LEN + 1); i++)
-        //   {
-        //     std::cout << std::hex << (int)ahrs_frame_.read_buf.read_msg[i] << " ";
-        //   }
-        //   std::cout << std::dec << std::endl;
-        // }
-        uint16_t CRC16 = CRC16_Table(ahrs_frame_.frame.data.data_buff, AHRS_LEN);
-        if (if_debug_){
-          std::cout << "CRC16:        " << std::hex << (int)CRC16 << std::dec << std::endl;
-          std::cout << "head_crc16:   " << std::hex << (int)head_crc16 << std::dec << std::endl;
-          std::cout << "head_crc16_h: " << std::hex << (int)head_crc16_h << std::dec << std::endl;
-          std::cout << "head_crc16_l: " << std::hex << (int)head_crc16_l << std::dec << std::endl;
-          bool if_right = ((int)head_crc16 == (int)CRC16);
-          std::cout << "if_right: " << if_right << std::endl;
-        }
-        if (head_crc16 != CRC16)
-        {
-          RCLCPP_WARN_STREAM_SKIPFIRST(this->get_logger(),"check crc16 faild(ahrs).");
-          continue;
-        }
-        else if(ahrs_frame_.frame.frame_end != FRAME_END)
-        {
-          RCLCPP_WARN_STREAM_SKIPFIRST(this->get_logger(),"check frame end.");
-          continue;
-        }
-      }
-      else if (head_type[0] == TYPE_INSGPS)
-      {
-        uint16_t head_crc16 = insgps_frame_.frame.header.header_crc16_l + ((uint16_t)insgps_frame_.frame.header.header_crc16_h << 8);
-        size_t data_s = serial_.read(insgps_frame_.read_buf.read_msg, (INSGPS_LEN + 1)); //48+1
-        uint16_t CRC16 = CRC16_Table(insgps_frame_.frame.data.data_buff, INSGPS_LEN);
-        if (head_crc16 != CRC16)
-        {
-          RCLCPP_WARN_STREAM_SKIPFIRST(this->get_logger(),"check crc16 faild(insgps).");
-          continue;
-        }
-        else if(insgps_frame_.frame.frame_end != FRAME_END)
-        {
-          RCLCPP_WARN_STREAM_SKIPFIRST(this->get_logger(),"check frame end.");
-          continue;
-        }
-      }
-      // 
-      // ============================ publish magyaw topic ========================================
-      if (head_type[0] == TYPE_AHRS)
-      {
-        // publish imu topic
-        sensor_msgs::msg::Imu imu_data, imu_trueEast_data;
-        imu_data.header.stamp = this->get_clock()->now();
-        imu_data.header.frame_id = imu_frame_id_.c_str();
-        Eigen::Quaterniond q_ahrs(ahrs_frame_.frame.data.data_pack.Qw,
-                                  ahrs_frame_.frame.data.data_pack.Qx,
-                                  ahrs_frame_.frame.data.data_pack.Qy,
-                                  ahrs_frame_.frame.data.data_pack.Qz);
-        Eigen::Quaterniond q_r =
-            Eigen::AngleAxisd(  PI, Eigen::Vector3d::UnitZ()) *
-            Eigen::AngleAxisd(  PI, Eigen::Vector3d::UnitY()) *
-            Eigen::AngleAxisd( 0.0, Eigen::Vector3d::UnitX());
-        Eigen::Quaterniond q_rr =
-            Eigen::AngleAxisd( 0.0, Eigen::Vector3d::UnitZ()) *
-            Eigen::AngleAxisd( 0.0, Eigen::Vector3d::UnitY()) *
-            Eigen::AngleAxisd(  PI, Eigen::Vector3d::UnitX());
-        Eigen::Quaterniond q_z =
-            Eigen::AngleAxisd(  PI, Eigen::Vector3d::UnitZ()) *
-            Eigen::AngleAxisd( 0.0, Eigen::Vector3d::UnitY()) *
-            Eigen::AngleAxisd( 0.0, Eigen::Vector3d::UnitX());
-        Eigen::Quaterniond q_xiao_rr =
-            Eigen::AngleAxisd( PI/2.0, Eigen::Vector3d::UnitZ()) *
-            Eigen::AngleAxisd(    0.0, Eigen::Vector3d::UnitY()) *
-            Eigen::AngleAxisd(     PI, Eigen::Vector3d::UnitX());
-        if (device_type_ == 0) //untransformed raw data
-        {
-          imu_data.orientation.w = ahrs_frame_.frame.data.data_pack.Qw;
-          imu_data.orientation.x = ahrs_frame_.frame.data.data_pack.Qx;
-          imu_data.orientation.y = ahrs_frame_.frame.data.data_pack.Qy;
-          imu_data.orientation.z = ahrs_frame_.frame.data.data_pack.Qz;
-          imu_data.angular_velocity.x = ahrs_frame_.frame.data.data_pack.RollSpeed;
-          imu_data.angular_velocity.y = ahrs_frame_.frame.data.data_pack.PitchSpeed;
-          imu_data.angular_velocity.z = ahrs_frame_.frame.data.data_pack.HeadingSpeed;
-          imu_data.linear_acceleration.x = imu_frame_.frame.data.data_pack.accelerometer_x;
-          imu_data.linear_acceleration.y = imu_frame_.frame.data.data_pack.accelerometer_y;
-          imu_data.linear_acceleration.z = imu_frame_.frame.data.data_pack.accelerometer_z;
-        }
-        else if (device_type_ == 1) // Coordinate transformation under ROS standard of imu single product
-        {
-          Eigen::Quaterniond q_out =  q_z * q_rr * q_ahrs;
-          imu_data.orientation.w = q_out.w();
-          imu_data.orientation.x = q_out.x();
-          imu_data.orientation.y = q_out.y();
-          imu_data.orientation.z = q_out.z();
-          imu_data.angular_velocity.x = ahrs_frame_.frame.data.data_pack.RollSpeed;
-          imu_data.angular_velocity.y = ahrs_frame_.frame.data.data_pack.PitchSpeed;
-          imu_data.angular_velocity.z = ahrs_frame_.frame.data.data_pack.HeadingSpeed;
-          imu_data.linear_acceleration.x = imu_frame_.frame.data.data_pack.accelerometer_x;
-          imu_data.linear_acceleration.y = imu_frame_.frame.data.data_pack.accelerometer_y;
-          imu_data.linear_acceleration.z = imu_frame_.frame.data.data_pack.accelerometer_z;
-        }
-        // imu_data.orientation_covariance[0] = imu_mag_cov[0];
-        // imu_data.orientation_covariance[4] = imu_mag_cov[1];
-        // imu_data.orientation_covariance[8] = imu_mag_cov[2];
-        // imu_data.angular_velocity_covariance[0] = imu_gyro_cov[0];
-        // imu_data.angular_velocity_covariance[4] = imu_gyro_cov[1];
-        // imu_data.angular_velocity_covariance[8] = imu_gyro_cov[2];
-        // imu_data.linear_acceleration_covariance[0] = imu_accel_cov[0];
-        // imu_data.linear_acceleration_covariance[4] = imu_accel_cov[1];
-        // imu_data.linear_acceleration_covariance[8] = imu_accel_cov[2];
-        imu_pub_->publish(imu_data);
-        // true East heading publish ----
-        tf2::Quaternion q_new;
-        tf2::Quaternion q_orig(
-          imu_data.orientation.x,
-          imu_data.orientation.y,
-          imu_data.orientation.z,
-          imu_data.orientation.w);
-        q_new = q_rot * q_orig;
-        q_new.normalize();
-
-        imu_trueEast_data.orientation.x = q_new.x();
-        imu_trueEast_data.orientation.y = q_new.y();
-        imu_trueEast_data.orientation.z = q_new.z();
-        imu_trueEast_data.orientation.w = q_new.w();
-        imu_trueEast_data.orientation_covariance = imu_data.orientation_covariance;
-        imu_trueEast_data.angular_velocity_covariance = imu_data.angular_velocity_covariance;
-        imu_trueEast_data.linear_acceleration_covariance = imu_data.linear_acceleration_covariance;
-        imu_trueEast_pub_->publish(imu_trueEast_data);
-        // ------------------------------
-
-        Eigen::Quaterniond rpy_q(imu_data.orientation.w,
-                                imu_data.orientation.x,
-                                imu_data.orientation.y,
-                                imu_data.orientation.z);
-        geometry_msgs::msg::Pose2D pose_2d;
-        double magx, magy, magz, roll, pitch;
-        if (device_type_ == 0){ //untransformed raw data//
-          magx  = imu_frame_.frame.data.data_pack.magnetometer_x;
-          magy  = imu_frame_.frame.data.data_pack.magnetometer_y;
-          magz  = imu_frame_.frame.data.data_pack.magnetometer_z;
-          roll  = ahrs_frame_.frame.data.data_pack.Roll;
-          pitch = ahrs_frame_.frame.data.data_pack.Pitch;
-        }
-        else if (device_type_ == 1){ //Coordinate transformation of car and imu single product ROS standard//
-          magx  = imu_frame_.frame.data.data_pack.magnetometer_x;
-          magy  = imu_frame_.frame.data.data_pack.magnetometer_y;
-          magz  = imu_frame_.frame.data.data_pack.magnetometer_z;
-
-          Eigen::Vector3d EulerAngle = rpy_q.matrix().eulerAngles(2, 1, 0);
-          roll  = EulerAngle[2];
-          pitch = EulerAngle[1];
-        }
-
-        // Convert mG to T
-        magx *= 1.0e-7;
-        magy *= 1.0e-7;
-        magz *= 1.0e-7;
-        magx -= mag_offset_x_;
-        magy -= mag_offset_y_;
-        magz -= mag_offset_z_;
-
-        double magyaw;
-        magCalculateYaw(roll, pitch, magyaw, magx, magy, magz);
-        pose_2d.theta = magyaw;
-        mag_pose_pub_->publish(pose_2d);
-
-        sensor_msgs::msg::MagneticField mag;
-        mag.header = imu_data.header;
-        mag.magnetic_field.x = magx;
-        mag.magnetic_field.y = magy;
-        mag.magnetic_field.z = magz;
-        std::fill(mag.magnetic_field_covariance.begin(), mag.magnetic_field_covariance.end(), mag_covariance_);
-        mag_pub_->publish(mag);
-      }
-      // printf(" %s : %i\n", serial_port_.c_str(), serial_baud_ );
-      // rclcpp::sleep_for(std::chrono::seconds(1));
+    if (!serial_.isOpen()) {
+      RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 2000, "Serial is not open");
+      return;
     }
-    
+
+    uint8_t check_head = 0xff;
+    if (!read_exact(&check_head, 1) || check_head != FRAME_HEAD) {
+      return;
+    }
+
+    uint8_t head_type = 0xff;
+    if (!read_exact(&head_type, 1)) {
+      return;
+    }
+
+    if (head_type != TYPE_IMU && head_type != TYPE_AHRS && head_type != TYPE_INSGPS &&
+      head_type != TYPE_GROUND && head_type != 0x50)
+    {
+      RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 2000, "Invalid frame type: 0x%02x", head_type);
+      return;
+    }
+
+    uint8_t frame_len = 0xff;
+    if (!read_exact(&frame_len, 1)) {
+      return;
+    }
+
+    if ((head_type == TYPE_IMU && frame_len != IMU_LEN) ||
+      (head_type == TYPE_AHRS && frame_len != AHRS_LEN) ||
+      (head_type == TYPE_INSGPS && frame_len != INSGPS_LEN))
+    {
+      RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 2000, "Length mismatch for frame type 0x%02x", head_type);
+      return;
+    }
+
+    if (head_type == TYPE_GROUND || head_type == 0x50) {
+      uint8_t ground_sn = 0;
+      if (!read_exact(&ground_sn, 1)) {
+        return;
+      }
+      update_sn(ground_sn);
+
+      std::array<uint8_t, 512> ignore{};
+      const size_t remain = static_cast<size_t>(frame_len) + 4;
+      read_exact(ignore.data(), remain);
+      return;
+    }
+
+    std::array<uint8_t, 4> header_tail{};
+    if (!read_exact(header_tail.data(), header_tail.size())) {
+      return;
+    }
+
+    const uint8_t serial_num = header_tail[0];
+    const uint8_t header_crc8 = header_tail[1];
+    const uint16_t header_crc16 = static_cast<uint16_t>(header_tail[3]) |
+      (static_cast<uint16_t>(header_tail[2]) << 8);
+
+    std::array<uint8_t, 4> header_for_crc = {check_head, head_type, frame_len, serial_num};
+    if (CRC8_Table(header_for_crc.data(), header_for_crc.size()) != header_crc8) {
+      RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 2000, "header crc8 error");
+      return;
+    }
+
+    if (!first_sn_) {
+      read_sn_ = static_cast<uint8_t>(serial_num - 1);
+      first_sn_ = true;
+    }
+    update_sn(serial_num);
+
+    if (head_type == TYPE_IMU) {
+      imu_frame_.frame.header = {check_head, head_type, frame_len, serial_num, header_crc8,
+        header_tail[2], header_tail[3]};
+      if (!read_exact(imu_frame_.read_buf.read_msg, IMU_LEN + 1)) {
+        return;
+      }
+      validate_and_publish_imu(header_crc16, imu_frame_.frame.data.data_buff, IMU_LEN,
+        imu_frame_.frame.frame_end, head_type);
+    } else if (head_type == TYPE_AHRS) {
+      ahrs_frame_.frame.header = {check_head, head_type, frame_len, serial_num, header_crc8,
+        header_tail[2], header_tail[3]};
+      if (!read_exact(ahrs_frame_.read_buf.read_msg, AHRS_LEN + 1)) {
+        return;
+      }
+      if (!validate_and_publish_imu(header_crc16, ahrs_frame_.frame.data.data_buff, AHRS_LEN,
+        ahrs_frame_.frame.frame_end, head_type))
+      {
+        return;
+      }
+      publish_messages();
+    } else if (head_type == TYPE_INSGPS) {
+      insgps_frame_.frame.header = {check_head, head_type, frame_len, serial_num, header_crc8,
+        header_tail[2], header_tail[3]};
+      if (!read_exact(insgps_frame_.read_buf.read_msg, INSGPS_LEN + 1)) {
+        return;
+      }
+      validate_and_publish_imu(header_crc16, insgps_frame_.frame.data.data_buff, INSGPS_LEN,
+        insgps_frame_.frame.frame_end, head_type);
+    }
   }
 
-  void magCalculateYaw(double roll, double pitch, double &magyaw, double magx, double magy, double magz)
+  bool validate_and_publish_imu(
+    uint16_t header_crc16,
+    const uint8_t * payload,
+    uint8_t expected_len,
+    uint8_t frame_end,
+    uint8_t frame_type)
   {
-    double temp1 = magy * cos(roll) + magz * sin(roll);
-    double temp2 = magx * cos(pitch) + magy * sin(pitch) * sin(roll) - magz * sin(pitch) * cos(roll);
-    magyaw = atan2(-temp1, temp2);
-    if(magyaw < 0)
-    {
-      magyaw = magyaw + 2 * PI;
+    const uint16_t crc16 = CRC16_Table(payload, expected_len);
+    if (crc16 != header_crc16) {
+      RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 2000, "crc16 failed type=0x%02x", frame_type);
+      ++crc_error_;
+      return false;
     }
-    // return magyaw;
+    if (frame_end != FRAME_END) {
+      RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 2000, "frame end invalid type=0x%02x", frame_type);
+      return false;
+    }
+    return true;
   }
 
-  void checkSN(int type)
+  void publish_messages()
   {
-    switch (type)
-    {
-    case TYPE_IMU:
-      if (++read_sn_ != imu_frame_.frame.header.serial_num)
-      {
-        if ( imu_frame_.frame.header.serial_num < read_sn_)
-        {
-          sn_lost_ += 256 - (int)(read_sn_ - imu_frame_.frame.header.serial_num);
-          if(if_debug_){
-            RCLCPP_WARN_STREAM_SKIPFIRST(this->get_logger(),"detected sn lost.");
-          }
-        }
-        else
-        {
-          sn_lost_ += (int)(imu_frame_.frame.header.serial_num - read_sn_);
-          if(if_debug_){
-            RCLCPP_WARN_STREAM_SKIPFIRST(this->get_logger(),"detected sn lost.");
-          }
-        }
-      }
-      read_sn_ = imu_frame_.frame.header.serial_num;
-      break;
+    sensor_msgs::msg::Imu imu_data;
+    imu_data.header.stamp = get_clock()->now();
+    imu_data.header.frame_id = imu_frame_id_;
 
-    case TYPE_AHRS:
-      if (++read_sn_ != ahrs_frame_.frame.header.serial_num)
-      {
-        if ( ahrs_frame_.frame.header.serial_num < read_sn_)
-        {
-          sn_lost_ += 256 - (int)(read_sn_ - ahrs_frame_.frame.header.serial_num);
-          if(if_debug_){
-            RCLCPP_WARN_STREAM_SKIPFIRST(this->get_logger(),"detected sn lost.");
-          }
-        }
-        else
-        {
-          sn_lost_ += (int)(ahrs_frame_.frame.header.serial_num - read_sn_);
-          if(if_debug_){
-            RCLCPP_WARN_STREAM_SKIPFIRST(this->get_logger(),"detected sn lost.");
-          }
-        }
-      }
-      read_sn_ = ahrs_frame_.frame.header.serial_num;
-      break;
+    const Eigen::Quaterniond q_rr =
+      Eigen::AngleAxisd(0.0, Eigen::Vector3d::UnitZ()) *
+      Eigen::AngleAxisd(0.0, Eigen::Vector3d::UnitY()) *
+      Eigen::AngleAxisd(PI, Eigen::Vector3d::UnitX());
+    const Eigen::Quaterniond q_z =
+      Eigen::AngleAxisd(PI, Eigen::Vector3d::UnitZ()) *
+      Eigen::AngleAxisd(0.0, Eigen::Vector3d::UnitY()) *
+      Eigen::AngleAxisd(0.0, Eigen::Vector3d::UnitX());
 
-    case TYPE_INSGPS:
-      if (++read_sn_ != insgps_frame_.frame.header.serial_num)
-      {
-        if ( insgps_frame_.frame.header.serial_num < read_sn_)
-        {
-          sn_lost_ += 256 - (int)(read_sn_ - insgps_frame_.frame.header.serial_num);
-          if(if_debug_){
-            RCLCPP_WARN_STREAM_SKIPFIRST(this->get_logger(),"detected sn lost.");
-          }
-        }
-        else
-        {
-          sn_lost_ += (int)(insgps_frame_.frame.header.serial_num - read_sn_);
-          if(if_debug_){
-            RCLCPP_WARN_STREAM_SKIPFIRST(this->get_logger(),"detected sn lost.");
-          }
-        }
-      }
-      read_sn_ = insgps_frame_.frame.header.serial_num;
-      break;
+    if (device_type_ == 0) {
+      imu_data.orientation.w = ahrs_frame_.frame.data.data_pack.Qw;
+      imu_data.orientation.x = ahrs_frame_.frame.data.data_pack.Qx;
+      imu_data.orientation.y = ahrs_frame_.frame.data.data_pack.Qy;
+      imu_data.orientation.z = ahrs_frame_.frame.data.data_pack.Qz;
+    } else {
+      const Eigen::Quaterniond q_ahrs(
+        ahrs_frame_.frame.data.data_pack.Qw,
+        ahrs_frame_.frame.data.data_pack.Qx,
+        ahrs_frame_.frame.data.data_pack.Qy,
+        ahrs_frame_.frame.data.data_pack.Qz);
+      const Eigen::Quaterniond q_out = q_z * q_rr * q_ahrs;
+      imu_data.orientation.w = q_out.w();
+      imu_data.orientation.x = q_out.x();
+      imu_data.orientation.y = q_out.y();
+      imu_data.orientation.z = q_out.z();
+    }
 
-    default:
-      break;
+    imu_data.angular_velocity.x = ahrs_frame_.frame.data.data_pack.RollSpeed;
+    imu_data.angular_velocity.y = ahrs_frame_.frame.data.data_pack.PitchSpeed;
+    imu_data.angular_velocity.z = ahrs_frame_.frame.data.data_pack.HeadingSpeed;
+    imu_data.linear_acceleration.x = imu_frame_.frame.data.data_pack.accelerometer_x;
+    imu_data.linear_acceleration.y = imu_frame_.frame.data.data_pack.accelerometer_y;
+    imu_data.linear_acceleration.z = imu_frame_.frame.data.data_pack.accelerometer_z;
+
+    set_diag_covariance(imu_data.orientation_covariance, imu_mag_cov_);
+    set_diag_covariance(imu_data.angular_velocity_covariance, imu_gyro_cov_);
+    set_diag_covariance(imu_data.linear_acceleration_covariance, imu_accel_cov_);
+
+    imu_pub_->publish(imu_data);
+
+    sensor_msgs::msg::Imu imu_true_east = imu_data;
+    tf2::Quaternion q_orig(
+      imu_data.orientation.x,
+      imu_data.orientation.y,
+      imu_data.orientation.z,
+      imu_data.orientation.w);
+    tf2::Quaternion q_new = q_rot_ * q_orig;
+    q_new.normalize();
+    imu_true_east.orientation.x = q_new.x();
+    imu_true_east.orientation.y = q_new.y();
+    imu_true_east.orientation.z = q_new.z();
+    imu_true_east.orientation.w = q_new.w();
+    imu_true_east_pub_->publish(imu_true_east);
+
+    const auto [roll, pitch] = compute_roll_pitch(imu_data);
+    double magx = imu_frame_.frame.data.data_pack.magnetometer_x * MAG_SCALE_MILLI_GAUSS_TO_TESLA - mag_offset_x_;
+    double magy = imu_frame_.frame.data.data_pack.magnetometer_y * MAG_SCALE_MILLI_GAUSS_TO_TESLA - mag_offset_y_;
+    double magz = imu_frame_.frame.data.data_pack.magnetometer_z * MAG_SCALE_MILLI_GAUSS_TO_TESLA - mag_offset_z_;
+
+    geometry_msgs::msg::Pose2D pose_2d;
+    pose_2d.theta = calculate_mag_yaw(roll, pitch, magx, magy, magz);
+    mag_pose_pub_->publish(pose_2d);
+
+    sensor_msgs::msg::MagneticField mag;
+    mag.header = imu_data.header;
+    mag.magnetic_field.x = magx;
+    mag.magnetic_field.y = magy;
+    mag.magnetic_field.z = magz;
+    std::fill(mag.magnetic_field_covariance.begin(), mag.magnetic_field_covariance.end(), mag_covariance_);
+    mag_pub_->publish(mag);
+  }
+
+  void set_diag_covariance(std::array<double, 9> & cov, const std::vector<double> & diagonal)
+  {
+    cov.fill(0.0);
+    if (diagonal.size() >= 3U) {
+      cov[0] = diagonal[0];
+      cov[4] = diagonal[1];
+      cov[8] = diagonal[2];
     }
   }
-  
-  //
+
+  std::pair<double, double> compute_roll_pitch(const sensor_msgs::msg::Imu & imu_data) const
+  {
+    if (device_type_ == 0) {
+      return {ahrs_frame_.frame.data.data_pack.Roll, ahrs_frame_.frame.data.data_pack.Pitch};
+    }
+
+    Eigen::Quaterniond q(
+      imu_data.orientation.w,
+      imu_data.orientation.x,
+      imu_data.orientation.y,
+      imu_data.orientation.z);
+    const Eigen::Vector3d euler = q.matrix().eulerAngles(2, 1, 0);
+    return {euler[2], euler[1]};
+  }
+
+  double calculate_mag_yaw(double roll, double pitch, double magx, double magy, double magz) const
+  {
+    const double temp1 = magy * std::cos(roll) + magz * std::sin(roll);
+    const double temp2 = magx * std::cos(pitch) +
+      magy * std::sin(pitch) * std::sin(roll) -
+      magz * std::sin(pitch) * std::cos(roll);
+    double magyaw = std::atan2(-temp1, temp2);
+    if (magyaw < 0.0) {
+      magyaw += 2.0 * PI;
+    }
+    return magyaw;
+  }
+
+  void update_sn(uint8_t current_sn)
+  {
+    if (++read_sn_ != current_sn) {
+      if (current_sn < read_sn_) {
+        sn_lost_ += 256 - static_cast<int>(read_sn_ - current_sn);
+      } else {
+        sn_lost_ += static_cast<int>(current_sn - read_sn_);
+      }
+      if (if_debug_) {
+        RCLCPP_WARN(get_logger(), "Detected serial number loss (lost total=%d)", sn_lost_);
+      }
+    }
+    read_sn_ = current_sn;
+  }
+
+private:
+  serial::Serial serial_;
+  bool if_debug_{false};
+
+  std::string serial_port_;
+  uint32_t serial_baud_{921600};
+  uint32_t serial_timeout_{20};
+
+  int sn_lost_{0};
+  int crc_error_{0};
+  uint8_t read_sn_{0};
+  bool first_sn_{false};
+  int device_type_{1};
+
+  std::vector<double> imu_mag_cov_;
+  std::vector<double> imu_gyro_cov_;
+  std::vector<double> imu_accel_cov_;
+
+  std::string imu_topic_;
+  std::string mag_pose_2d_topic_;
+  std::string imu_true_east_topic_;
+  std::string mag_topic_;
+  std::string imu_frame_id_;
+
+  double yaw_offset_{-2.094};
+  tf2::Quaternion q_rot_;
+  double mag_offset_x_{0.0};
+  double mag_offset_y_{0.0};
+  double mag_offset_z_{0.0};
+  double mag_covariance_{0.01};
+
+  FDILink::imu_frame_read imu_frame_{};
+  FDILink::ahrs_frame_read ahrs_frame_{};
+  FDILink::insgps_frame_read insgps_frame_{};
+
   rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr imu_pub_;
-  rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr imu_trueEast_pub_;
+  rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr imu_true_east_pub_;
   rclcpp::Publisher<geometry_msgs::msg::Pose2D>::SharedPtr mag_pose_pub_;
   rclcpp::Publisher<sensor_msgs::msg::MagneticField>::SharedPtr mag_pub_;
   rclcpp::TimerBase::SharedPtr timer_;
@@ -636,9 +404,6 @@ private:
 
 int main(int argc, char ** argv)
 {
-  (void) argc;
-  (void) argv;
-
   rclcpp::init(argc, argv);
   auto node = std::make_shared<ImuNode>();
   rclcpp::spin(node);


### PR DESCRIPTION
### Motivation
- Port and stabilize the WHEELTEC N100 IMU driver to ROS 2 Jazzy / modern toolchain and clean up the experimental `work` code.
- Improve runtime reliability by replacing the previous busy-loop serial handling with a single-frame-per-timer processing model and stronger error handling.
- Make CRC utilities a proper API and fix their signatures to be safer and size-aware.
- Reduce duplication and improve maintainability by centralizing parameter declaration/loading and common constants.

### Description
- Refactored `imu_node.cpp` into a safer, clearer implementation with `declare_parameters()`, `load_parameters()`, `setup_serial()`, per-tick `read_imu()` processing, CRC/header validation helpers, SN tracking (`update_sn`), and message publish helpers (`publish_messages`).
- Added `include/wheeltec_n100_imu/crc_table.hpp` and updated `src/crc_table.cpp` to use `const uint8_t *` + `size_t` signatures and corrected the CRC32 computation implementation.
- Reworked package build files: bumped C++ standard to 17 in `CMakeLists.txt`, added `src/crc_table.cpp` to the target, removed unused deps (`std_msgs`, `rcl_interfaces`) from `CMakeLists.txt` and `package.xml`, and kept required ROS2 dependencies (`rclcpp`, `sensor_msgs`, `tf2`, `serial`, `Eigen3`).
- Cleaned and updated the root `README.md` to mention the new `jazzy` branch and provide a quick run example for ROS 2 Jazzy.

### Testing
- Attempted `colcon build --packages-select wheeltec_n100_imu` which failed in this environment because `colcon` is not installed (automated build did not run).
- Attempted CMake build with `cmake -S ros2_wheeltec_n100_imu -B /tmp/wheeltec_build && cmake --build /tmp/wheeltec_build -j` which failed due to missing ROS/ament environment (`ament_cmake` not found) in this container.
- No unit tests were added; runtime validation with a sourced ROS 2 Jazzy workspace and a real `/dev/tty*` IMU device is recommended to verify end-to-end behavior and timing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3a1e3e27c832e8bbd8e5294882bb1)